### PR TITLE
Patch for python3

### DIFF
--- a/DingCallbackCrypto3.py
+++ b/DingCallbackCrypto3.py
@@ -4,7 +4,7 @@
 #  code copy from https://github.com/shuizhengqi1/DingCrypto/blob/master/DingCrypto.py
 
 # 依赖Crypto类库
-# sudo pip3 install pycrypto  python3 安装Crypto
+# sudo pip3 install pycryptodome  python3 安装Crypto  (原pycrypto已经多年不维护，安装报错）
 # API说明
 # getEncryptedMap 生成回调处理成功后success加密后返回给钉钉的json数据
 # decrypt  用于从钉钉接收到回调请求后

--- a/DingCallbackCrypto3.py
+++ b/DingCallbackCrypto3.py
@@ -88,7 +88,7 @@ class DingCallbackCrypto3:
         contentEncode = self.pks7encode(content)
         iv = self.aesKey[:16]
         aesEncode = AES.new(self.aesKey, AES.MODE_CBC, iv)
-        aesEncrypt = aesEncode.encrypt(contentEncode)
+        aesEncrypt = aesEncode.encrypt(contentEncode.encode('UTF-8'))
         return base64.encodebytes(aesEncrypt).decode('UTF-8')
 
     ### 生成回调返回使用的签名值


### PR DESCRIPTION
解决问题 #2 
1. python3版本，注释中的包pycrypto已经过时，无法安装。改为pycryptodome。
2. 运行的时候报错“Object type <class 'str'> cannot be passed to C code”，需要utf8编码。 