### PR TITLE
PHP7不支持同类名的方法名当做构造函数DingCallbackCrypto.php

### DIFF
--- a/DingCallbackCrypto.php
+++ b/DingCallbackCrypto.php
@@ -193,7 +193,7 @@ class Prpcrypt
 {
 	public $key;
 
-	function Prpcrypt($k)
+	function __construct($k)
 	{
 		$this->key = base64_decode($k . "=");
 	}


### PR DESCRIPTION
PHP7不支持同类名的方法名当做构造函数，更换为 `__construct`