### PR TITLE
Update DingCallbackCrypto.php

### DIFF
--- a/DingCallbackCrypto.php
+++ b/DingCallbackCrypto.php
@@ -193,7 +193,7 @@ class Prpcrypt
 {
 	public $key;
 
-	function Prpcrypt($k)
+	function __construct($k)
 	{
 		$this->key = base64_decode($k . "=");
 	}


### PR DESCRIPTION
fix 代码被加上 namespace 后，会不正常；自 PHP 5.3.3 起，在命名空间中，与类名同名的方法不再作为构造函数。这一改变不影响不在命名空间中的类